### PR TITLE
chore(release): 0.51.2

### DIFF
--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -1,0 +1,31 @@
+name: On Opened PR
+
+on:
+  workflow_run:
+    workflows: ["Record PR"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  get-pr-details:
+    permissions:
+      actions: read # download PR artifact
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: aws-deadline/.github/.github/workflows/reusable_extract_pr_details.yml@mainline
+    with:
+      record_pr_workflow_id: ${{ github.event.workflow_run.id }}
+      artifact_name: "pr-info"
+      workflow_origin: ${{ github.repository }}
+
+  label-pr:
+    needs: get-pr-details
+    if: ${{ needs.get-pr-details.outputs.pr_action == 'opened' || needs.get-pr-details.outputs.pr_action == 'reopened' }}
+    uses: aws-deadline/.github/.github/workflows/reusable_label_pr.yml@mainline
+    with:
+      pr_number: ${{ needs.get-pr-details.outputs.pr_number }}
+      label_name: "waiting-on-maintainers"
+    permissions:
+      pull-requests: write

--- a/.github/workflows/record_pr.yml
+++ b/.github/workflows/record_pr.yml
@@ -1,0 +1,9 @@
+name: Record PR
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  call-record-workflow:
+    uses: aws-deadline/.github/.github/workflows/reusable_record_pr_details.yml@mainline

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   Bump:
     name: Version Bump
-    uses: aws-deadline/.github/.github/workflows/reusable_bump.yml@mainline
+    uses: moorec-aws/.github/.github/workflows/reusable_bump.yml@mainline
     secrets: inherit
     with:
       force_version_bump: ${{ inputs.force_version_bump }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.51.2 (2025-08-08)
+
+
+### Features
+* Add functions to support path mapping ([`5a28a64`](https://github.com/moorec-aws/deadline-cloud/commit/5a28a648604970280f505583567e1ad82a5ed86e))
+* refactor the autorization UI dialog (#751) ([`5882533`](https://github.com/moorec-aws/deadline-cloud/commit/5882533ca8a3e65a0cc36083998521b1631f92a1))
+* Adding target_task_run_status optional to create_job_from_job_bundle and deadline bundle submit (#753) ([`344b6f6`](https://github.com/moorec-aws/deadline-cloud/commit/344b6f67a6c1122833f227555b6f8b20a3f126f0))
+
+### Bug Fixes
+* test ([`0e2dd38`](https://github.com/moorec-aws/deadline-cloud/commit/0e2dd38e2b12f074db147dbf05657f9da84dfc1b))
+* QSpinBox values not updating without focus loss (#770) ([`fb6741d`](https://github.com/moorec-aws/deadline-cloud/commit/fb6741d8a54b5d7d317d4520107772c7ca6f643f))
+* Change the return type for OnCreateJobBundleCallback to accept None. (#760) ([`822052f`](https://github.com/moorec-aws/deadline-cloud/commit/822052fc7ddabcf9ebe0aaefc58e345e181eeb0d))
+* Switching job causes submission error in GUI submitter (#757) ([`a3a1eba`](https://github.com/moorec-aws/deadline-cloud/commit/a3a1eba49a75aeaad810e229acc27f29cf1369a0))
+
 ## 0.51.0 (2025-07-28)
 
 


### PR DESCRIPTION
## 0.51.2 (2025-08-08)


### Features
* Add functions to support path mapping ([`5a28a64`](https://github.com/moorec-aws/deadline-cloud/commit/5a28a648604970280f505583567e1ad82a5ed86e))
* refactor the autorization UI dialog (#751) ([`5882533`](https://github.com/moorec-aws/deadline-cloud/commit/5882533ca8a3e65a0cc36083998521b1631f92a1))
* Adding target_task_run_status optional to create_job_from_job_bundle and deadline bundle submit (#753) ([`344b6f6`](https://github.com/moorec-aws/deadline-cloud/commit/344b6f67a6c1122833f227555b6f8b20a3f126f0))

### Bug Fixes
* test ([`0e2dd38`](https://github.com/moorec-aws/deadline-cloud/commit/0e2dd38e2b12f074db147dbf05657f9da84dfc1b))
* QSpinBox values not updating without focus loss (#770) ([`fb6741d`](https://github.com/moorec-aws/deadline-cloud/commit/fb6741d8a54b5d7d317d4520107772c7ca6f643f))
* Change the return type for OnCreateJobBundleCallback to accept None. (#760) ([`822052f`](https://github.com/moorec-aws/deadline-cloud/commit/822052fc7ddabcf9ebe0aaefc58e345e181eeb0d))
* Switching job causes submission error in GUI submitter (#757) ([`a3a1eba`](https://github.com/moorec-aws/deadline-cloud/commit/a3a1eba49a75aeaad810e229acc27f29cf1369a0))
